### PR TITLE
Add current line and column number to ParseException thrown in Markup…

### DIFF
--- a/src/main/java/org/attoparser/MarkupParser.java
+++ b/src/main/java/org/attoparser/MarkupParser.java
@@ -390,7 +390,7 @@ public final class MarkupParser implements IMarkupParser {
         } catch (final ParseException e) {
             throw e;
         } catch (final Exception e) {
-            throw new ParseException(e);
+            throw new ParseException(e, status.line, status.col);
         } finally {
             this.pool.releaseBuffer(buffer);
             try {


### PR DESCRIPTION
This is a very trivial change that adds current line and column number to the `ParseException` instance being thrown in `org.attoparser.MarkupParser.parseDocument(Reader, int, IMarkupHandler, ParseStatus)` general catch block.

I came to this issue while investigating some parsing exceptions being thrown in thymeleaf (for example when `org.thymeleaf.engine.AttributeDefinitions.forHTMLName(char[], int, int)` is called with parameter `attributeName` empty)



